### PR TITLE
Refine browser.storage API

### DIFF
--- a/__tests__/storage.test.js
+++ b/__tests__/storage.test.js
@@ -14,47 +14,86 @@ describe('browser.storage', () => {
   ['sync', 'local', 'managed'].forEach(type => {
     describe(type, () => {
       const storage = browser.storage[type];
-      test('get', done => {
-        const callback = jest.fn(() => done());
+      describe('get', () => {
         expect(jest.isMockFunction(storage.get)).toBe(true);
-        storage.get(1, callback);
-        expect(storage.get).toHaveBeenCalledTimes(1);
-        expect(callback).toBeCalled();
+        test('a string key', done => {
+          const key = 'test';
+          storage.get(key, result => {
+            expect(result).toBeDefined();
+            expect(typeof result === 'object').toBeTruthy();
+            expect(result).toHaveProperty(key, '');
+            done();
+          });
+        });
+        test('an array key', done => {
+          const keys = ['test1', 'test2'];
+          storage.get(keys, result => {
+            expect(result).toBeDefined();
+            expect(typeof result === 'object').toBeTruthy();
+            keys.forEach(k => {
+              expect(result).toHaveProperty(k);
+            });
+            done();
+          });
+        });
+        test('an object key', done => {
+          const key = { test: [] };
+          storage.get(key, result => {
+            expect(result).toBeDefined();
+            expect(typeof result === 'object').toBeTruthy();
+            Object.keys(key).forEach(k => {
+              expect(result).toHaveProperty(k);
+              expect(result[k]).toEqual(key[k]);
+            });
+            done();
+          });
+        });
+        test('a invalid key', () => {
+          try {
+            storage.get(1, jest.fn());
+            expect.toThrow;
+          } catch (e) {
+            expect(e.message).toBe('Wrong key given');
+          }
+        });
+        afterEach(() => {
+          expect(storage.get).toHaveBeenCalledTimes(1);
+          storage.get.mockClear();
+        });
       });
       test('get promise', () => {
-        return expect(storage.get(1)).resolves.toMatchObject({ id: 1 });
+        const key = 'key';
+        return expect(storage.get(key)).resolves.toEqual({ key: '' });
       });
       test('getBytesInUse', done => {
         const callback = jest.fn(() => done());
         expect(jest.isMockFunction(storage.getBytesInUse)).toBe(true);
-        storage.getBytesInUse(1, callback);
+        storage.getBytesInUse('key', callback);
         expect(storage.getBytesInUse).toHaveBeenCalledTimes(1);
         expect(callback).toBeCalled();
       });
       test('getBytesInUse promise', () => {
-        return expect(storage.getBytesInUse(1)).resolves.toMatchObject({
-          id: 1,
-        });
+        return expect(storage.getBytesInUse('key')).resolves.toBe(0);
       });
       test('set', done => {
         const callback = jest.fn(() => done());
         expect(jest.isMockFunction(storage.set)).toBe(true);
-        storage.set(1, callback);
+        storage.set({ key: '' }, callback);
         expect(storage.set).toHaveBeenCalledTimes(1);
         expect(callback).toBeCalled();
       });
       test('set promise', () => {
-        return expect(storage.set(1)).resolves.toMatchObject({ id: 1 });
+        return expect(storage.set(1)).resolves.toBeUndefined();
       });
       test('remove', done => {
         const callback = jest.fn(() => done());
         expect(jest.isMockFunction(storage.remove)).toBe(true);
-        storage.remove(1, callback);
+        storage.remove('key', callback);
         expect(storage.remove).toHaveBeenCalledTimes(1);
         expect(callback).toBeCalled();
       });
       test('remove promise', () => {
-        return expect(storage.remove(1)).resolves.toMatchObject({ id: 1 });
+        return expect(storage.remove(1)).resolves.toBeUndefined();
       });
       test('clear', done => {
         const callback = jest.fn(() => done());

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,28 +1,45 @@
+function resolveKey(key) {
+  if (typeof key === 'string') {
+    const result = {};
+    result[key] = '';
+    return result;
+  } else if (Array.isArray(key)) {
+    return key.reduce((acc, curr) => {
+      acc[curr] = '';
+      return acc;
+    }, {});
+  } else if (typeof key === 'object') {
+    return key;
+  }
+  throw new Error('Wrong key given');
+}
+
 export const storage = {
   sync: {
     get: jest.fn((id, cb) => {
+      const result = resolveKey(id);
       if (cb !== undefined) {
-        return cb({ id });
+        return cb(result);
       }
-      return Promise.resolve({ id });
+      return Promise.resolve(result);
     }),
     getBytesInUse: jest.fn((id, cb) => {
       if (cb !== undefined) {
-        return cb({ id });
+        return cb(0);
       }
-      return Promise.resolve({ id });
+      return Promise.resolve(0);
     }),
     set: jest.fn((id, cb) => {
       if (cb !== undefined) {
-        return cb({ id });
+        return cb();
       }
-      return Promise.resolve({ id });
+      return Promise.resolve();
     }),
     remove: jest.fn((id, cb) => {
       if (cb !== undefined) {
-        return cb({ id });
+        return cb();
       }
-      return Promise.resolve({ id });
+      return Promise.resolve();
     }),
     clear: jest.fn(cb => {
       if (cb !== undefined) {
@@ -33,28 +50,29 @@ export const storage = {
   },
   local: {
     get: jest.fn((id, cb) => {
+      const result = resolveKey(id);
       if (cb !== undefined) {
-        return cb({ id });
+        return cb(result);
       }
-      return Promise.resolve({ id });
+      return Promise.resolve(result);
     }),
     getBytesInUse: jest.fn((id, cb) => {
       if (cb !== undefined) {
-        return cb({ id });
+        return cb(0);
       }
-      return Promise.resolve({ id });
+      return Promise.resolve(0);
     }),
     set: jest.fn((id, cb) => {
       if (cb !== undefined) {
-        return cb({ id });
+        return cb();
       }
-      return Promise.resolve({ id });
+      return Promise.resolve();
     }),
     remove: jest.fn((id, cb) => {
       if (cb !== undefined) {
-        return cb({ id });
+        return cb();
       }
-      return Promise.resolve({ id });
+      return Promise.resolve();
     }),
     clear: jest.fn(cb => {
       if (cb !== undefined) {
@@ -65,28 +83,29 @@ export const storage = {
   },
   managed: {
     get: jest.fn((id, cb) => {
+      const result = resolveKey(id);
       if (cb !== undefined) {
-        return cb({ id });
+        return cb(result);
       }
-      return Promise.resolve({ id });
+      return Promise.resolve(result);
     }),
     getBytesInUse: jest.fn((id, cb) => {
       if (cb !== undefined) {
-        return cb({ id });
+        return cb(0);
       }
-      return Promise.resolve({ id });
+      return Promise.resolve(0);
     }),
     set: jest.fn((id, cb) => {
       if (cb !== undefined) {
-        return cb({ id });
+        return cb();
       }
-      return Promise.resolve({ id });
+      return Promise.resolve();
     }),
     remove: jest.fn((id, cb) => {
       if (cb !== undefined) {
-        return cb({ id });
+        return cb();
       }
-      return Promise.resolve({ id });
+      return Promise.resolve();
     }),
     clear: jest.fn(cb => {
       if (cb !== undefined) {


### PR DESCRIPTION
This PR is trying to fix #45 

I refine following functions in `browser.strorage`:

* Return correct value for `get` function.
* Return correct value for `getBytesInUse` function which are suppose to return integer.
* Return correct value for `set` and `remove` function which are suppose to return nothing.


@clarkbw let me know if there's anything I'm doing wrong, thanks