### PR TITLE
Added removeListener and hasListener

### DIFF
--- a/__tests__/runtime.test.js
+++ b/__tests__/runtime.test.js
@@ -21,18 +21,22 @@ describe('browser.runtime', () => {
   test('sendMessage promise', () => {
     return expect(browser.runtime.sendMessage({})).resolves.toBeUndefined();
   });
-  test('onMessage.addListener', () => {
-    expect(jest.isMockFunction(browser.runtime.onMessage.addListener)).toBe(
-      true
-    );
-    browser.runtime.onMessage.addListener();
-    expect(browser.runtime.onMessage.addListener).toHaveBeenCalledTimes(1);
+  ['addListener', 'removeListener', 'hasListener'].forEach(method => {
+    test(`onMessage.${method}`, () => {
+      const callback = jest.fn();
+      expect(jest.isMockFunction(browser.runtime.onMessage[method])).toBe(true);
+      browser.runtime.onMessage[method](callback);
+      expect(browser.runtime.onMessage[method]).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledTimes(0);
+    });
   });
-  test('onConnect.addListener', () => {
-    expect(jest.isMockFunction(browser.runtime.onConnect.addListener)).toBe(
-      true
-    );
-    browser.runtime.onConnect.addListener(() => {});
-    expect(browser.runtime.onConnect.addListener).toHaveBeenCalledTimes(1);
+  ['addListener', 'removeListener', 'hasListener'].forEach(method => {
+    test(`onConnect.${method}`, () => {
+      const callback = jest.fn();
+      expect(jest.isMockFunction(browser.runtime.onConnect[method])).toBe(true);
+      browser.runtime.onConnect[method](callback);
+      expect(browser.runtime.onConnect[method]).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledTimes(0);
+    });
   });
 });

--- a/__tests__/storage.test.js
+++ b/__tests__/storage.test.js
@@ -1,12 +1,12 @@
 describe('browser.storage', () => {
-  test('onChanged.addListener', () => {
-    const callback = jest.fn();
-    expect(jest.isMockFunction(browser.storage.onChanged.addListener)).toBe(
-      true
-    );
-    browser.storage.onChanged.addListener(callback);
-    expect(browser.storage.onChanged.addListener).toHaveBeenCalledTimes(1);
-    expect(callback).toHaveBeenCalledTimes(0);
+  ['addListener', 'removeListener', 'hasListener'].forEach(method => {
+    test(`onChanged.${method}`, () => {
+      const callback = jest.fn();
+      expect(jest.isMockFunction(browser.storage.onChanged[method])).toBe(true);
+      browser.storage.onChanged[method](callback);
+      expect(browser.storage.onChanged[method]).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledTimes(0);
+    });
   });
 });
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -20,8 +20,12 @@ export const runtime = {
   }),
   onMessage: {
     addListener: jest.fn(),
+    removeListener: jest.fn(),
+    hasListener: jest.fn(),
   },
   onConnect: {
     addListener: jest.fn(),
+    removeListener: jest.fn(),
+    hasListener: jest.fn(),
   },
 };

--- a/src/storage.js
+++ b/src/storage.js
@@ -116,5 +116,7 @@ export const storage = {
   },
   onChanged: {
     addListener: jest.fn(),
+    removeListener: jest.fn(),
+    hasListener: jest.fn(),
   },
 };


### PR DESCRIPTION
Added `removeListener` and `hasListener` to `storage.onChanged`, `runtime.onMessage` and `runtime.onConnect`.

Though they are not listed on Chrome's doc, Chrome always supports them and they can be found on the [schema](https://chromium.googlesource.com/chromium/src/+/master/extensions/common/api/events.json).

They can also be found on the WebExtension doc on MDN.

