### PR TITLE
Improve Storage

### DIFF
--- a/__tests__/storage.test.js
+++ b/__tests__/storage.test.js
@@ -57,7 +57,11 @@ describe('browser.storage', () => {
         });
         afterEach(() => {
           expect(storage.get).toHaveBeenCalledTimes(1);
+          storage.clear();
           storage.get.mockClear();
+          storage.set.mockClear();
+          storage.remove.mockClear();
+          storage.clear.mockClear();
         });
       });
       test('get promise', () => {

--- a/__tests__/storage.test.js
+++ b/__tests__/storage.test.js
@@ -92,7 +92,7 @@ describe('browser.storage', () => {
         expect(callback).toBeCalled();
       });
       test('remove promise', () => {
-        return expect(storage.remove(1)).resolves.toBeUndefined();
+        return expect(storage.remove(['foo', 'bar'])).resolves.toBeUndefined();
       });
       test('clear', done => {
         const callback = jest.fn(() => done());

--- a/__tests__/storage.test.js
+++ b/__tests__/storage.test.js
@@ -108,6 +108,41 @@ describe('browser.storage', () => {
       test('clear promise', () => {
         return expect(storage.clear()).resolves.toBeUndefined();
       });
+      test('real scenario', done => {
+        expect(jest.isMockFunction(storage.get)).toBe(true);
+        expect(jest.isMockFunction(storage.set)).toBe(true);
+        expect(jest.isMockFunction(storage.remove)).toBe(true);
+        expect(jest.isMockFunction(storage.clear)).toBe(true);
+        // set keys
+        storage.set({ key: 'value', foo: 'bar', foo2: 'bar2' }, () => {
+          // get 'key'
+          storage.get(['key'], result => {
+            expect(result).toBeDefined();
+            expect(typeof result === 'object').toBeTruthy();
+            expect(result).toHaveProperty('key', 'value');
+            expect(result).not.toHaveProperty('foo');
+            expect(result).not.toHaveProperty('foo2');
+            // remove 'key'
+            storage.remove('key', () => {
+              // get all values
+              storage.get(null, result => {
+                expect(result).toHaveProperty('key', undefined);
+                expect(result).toHaveProperty('foo', 'bar');
+                expect(result).toHaveProperty('foo2', 'bar2');
+                // clear values
+                storage.clear(() => {
+                  storage.get(['key', 'foo', 'foo2'], result => {
+                    expect(result).toHaveProperty('key', undefined);
+                    expect(result).toHaveProperty('foo', undefined);
+                    expect(result).toHaveProperty('foo2', undefined);
+                    done();
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
     });
   });
 });

--- a/__tests__/storage.test.js
+++ b/__tests__/storage.test.js
@@ -51,7 +51,6 @@ describe('browser.storage', () => {
         test('a invalid key', () => {
           try {
             storage.get(1, jest.fn());
-            expect.toThrow;
           } catch (e) {
             expect(e.message).toBe('Wrong key given');
           }

--- a/__tests__/storage.test.js
+++ b/__tests__/storage.test.js
@@ -21,7 +21,7 @@ describe('browser.storage', () => {
           storage.get(key, result => {
             expect(result).toBeDefined();
             expect(typeof result === 'object').toBeTruthy();
-            expect(result).toHaveProperty(key, '');
+            expect(result).toHaveProperty(key, undefined);
             done();
           });
         });
@@ -31,7 +31,7 @@ describe('browser.storage', () => {
             expect(result).toBeDefined();
             expect(typeof result === 'object').toBeTruthy();
             keys.forEach(k => {
-              expect(result).toHaveProperty(k);
+              expect(result).toHaveProperty(k, undefined);
             });
             done();
           });
@@ -63,7 +63,7 @@ describe('browser.storage', () => {
       });
       test('get promise', () => {
         const key = 'key';
-        return expect(storage.get(key)).resolves.toEqual({ key: '' });
+        return expect(storage.get(key)).resolves.toEqual({ key: undefined });
       });
       test('getBytesInUse', done => {
         const callback = jest.fn(() => done());
@@ -78,7 +78,7 @@ describe('browser.storage', () => {
       test('set', done => {
         const callback = jest.fn(() => done());
         expect(jest.isMockFunction(storage.set)).toBe(true);
-        storage.set({ key: '' }, callback);
+        storage.set({ key: 'foo' }, callback);
         expect(storage.set).toHaveBeenCalledTimes(1);
         expect(callback).toBeCalled();
       });

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,15 +1,20 @@
+const store = {};
+
 function resolveKey(key) {
   if (typeof key === 'string') {
     const result = {};
-    result[key] = '';
+    result[key] = store[key];
     return result;
   } else if (Array.isArray(key)) {
     return key.reduce((acc, curr) => {
-      acc[curr] = '';
+      acc[curr] = store[curr];
       return acc;
     }, {});
   } else if (typeof key === 'object') {
-    return key;
+    return Object.keys(key).reduce((acc, curr) => {
+      acc[curr] = store[curr] || key[curr];
+      return acc;
+    }, {});
   }
   throw new Error('Wrong key given');
 }

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,4 +1,4 @@
-const store = {};
+let store = {};
 
 function resolveKey(key) {
   if (typeof key === 'string') {
@@ -34,19 +34,23 @@ export const storage = {
       }
       return Promise.resolve(0);
     }),
-    set: jest.fn((id, cb) => {
+    set: jest.fn((payload, cb) => {
+      Object.keys(payload).forEach(key => (store[key] = payload[key]));
       if (cb !== undefined) {
         return cb();
       }
       return Promise.resolve();
     }),
     remove: jest.fn((id, cb) => {
+      const keys = typeof id === 'string' ? [id] : id;
+      keys.forEach(key => delete store[key]);
       if (cb !== undefined) {
         return cb();
       }
       return Promise.resolve();
     }),
     clear: jest.fn(cb => {
+      store = {};
       if (cb !== undefined) {
         return cb();
       }
@@ -67,19 +71,23 @@ export const storage = {
       }
       return Promise.resolve(0);
     }),
-    set: jest.fn((id, cb) => {
+    set: jest.fn((payload, cb) => {
+      Object.keys(payload).forEach(key => (store[key] = payload[key]));
       if (cb !== undefined) {
         return cb();
       }
       return Promise.resolve();
     }),
     remove: jest.fn((id, cb) => {
+      const keys = typeof id === 'string' ? [id] : id;
+      keys.forEach(key => delete store[key]);
       if (cb !== undefined) {
         return cb();
       }
       return Promise.resolve();
     }),
     clear: jest.fn(cb => {
+      store = {};
       if (cb !== undefined) {
         return cb();
       }
@@ -100,19 +108,23 @@ export const storage = {
       }
       return Promise.resolve(0);
     }),
-    set: jest.fn((id, cb) => {
+    set: jest.fn((payload, cb) => {
+      Object.keys(payload).forEach(key => (store[key] = payload[key]));
       if (cb !== undefined) {
         return cb();
       }
       return Promise.resolve();
     }),
     remove: jest.fn((id, cb) => {
+      const keys = typeof id === 'string' ? [id] : id;
+      keys.forEach(key => delete store[key]);
       if (cb !== undefined) {
         return cb();
       }
       return Promise.resolve();
     }),
     clear: jest.fn(cb => {
+      store = {};
       if (cb !== undefined) {
         return cb();
       }

--- a/src/storage.js
+++ b/src/storage.js
@@ -22,7 +22,7 @@ function resolveKey(key) {
 export const storage = {
   sync: {
     get: jest.fn((id, cb) => {
-      const result = resolveKey(id);
+      const result = id === null ? store : resolveKey(id);
       if (cb !== undefined) {
         return cb(result);
       }
@@ -55,7 +55,7 @@ export const storage = {
   },
   local: {
     get: jest.fn((id, cb) => {
-      const result = resolveKey(id);
+      const result = id === null ? store : resolveKey(id);
       if (cb !== undefined) {
         return cb(result);
       }
@@ -88,7 +88,7 @@ export const storage = {
   },
   managed: {
     get: jest.fn((id, cb) => {
-      const result = resolveKey(id);
+      const result = id === null ? store : resolveKey(id);
       if (cb !== undefined) {
         return cb(result);
       }


### PR DESCRIPTION
Related to my question (#63) this morning.

So I made some changes on Storage:
- it use a real store for setting and getting values
- `get` should returns the whole store if 1st argument is `null`
- `get` now returns `undefined` instead of empty string (if needed)
- `get` now supports default values (when key is an object)
- `set` interacts with the store
- `remove` now supports array of strings as key
- `clear` clears the store :smile: 

I also add a _real scenario_ in tests. It's pretty deep-nested but I think it's necessary.

And finally, it close #63  