### PR TITLE
Adding browser.runtime.getURL

### DIFF
--- a/__tests__/runtime.test.js
+++ b/__tests__/runtime.test.js
@@ -9,6 +9,13 @@ describe('browser.runtime', () => {
     expect(jest.isMockFunction(connection.onMessage.addListener)).toBe(true);
     expect(browser.runtime.connect).toHaveBeenCalledTimes(1);
   });
+  test('getURL', () => {
+    const path = 'TEST_PATH';
+    expect(jest.isMockFunction(browser.runtime.getURL)).toBe(true);
+    const respPath = browser.runtime.getURL(path);
+    expect(respPath).toEqual(path);
+    expect(browser.runtime.getURL).toHaveBeenCalledTimes(1);
+  });
   test('sendMessage', done => {
     const callback = jest.fn(() => done());
     expect(jest.isMockFunction(browser.runtime.sendMessage)).toBe(true);

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -28,4 +28,7 @@ export const runtime = {
     removeListener: jest.fn(),
     hasListener: jest.fn(),
   },
+  getURL: jest.fn(function(path) {
+    return path;
+  }),
 };


### PR DESCRIPTION
This adds the [`browser.runtime.getURL`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getURL) command to the mock. Currently it just returns whatever path is passed in to it.