### PR TITLE
feat: Added support for chrome.webNavigation API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# IDE
+.idea

--- a/__tests__/runtime.test.js
+++ b/__tests__/runtime.test.js
@@ -14,6 +14,7 @@ describe('browser.runtime', () => {
     expect(jest.isMockFunction(connection.postMessage)).toBe(true);
     expect(jest.isMockFunction(connection.onDisconnect.addListener)).toBe(true);
     expect(jest.isMockFunction(connection.onMessage.addListener)).toBe(true);
+    expect(jest.isMockFunction(connection.disconnect)).toBe(true);
     expect(browser.runtime.connect).toHaveBeenCalledTimes(1);
   });
   test('connect.onMessage listener', done => {
@@ -97,5 +98,10 @@ describe('browser.runtime', () => {
       expect(browser.runtime.onInstalled[method]).toHaveBeenCalledTimes(1);
       expect(callback).toHaveBeenCalledTimes(0);
     });
+  });
+  test('openOptionsPage', () => {
+    expect(jest.isMockFunction(browser.runtime.openOptionsPage)).toBe(true);
+    browser.runtime.openOptionsPage();
+    expect(browser.runtime.openOptionsPage).toHaveBeenCalledTimes(1);
   });
 });

--- a/__tests__/tabs.test.js
+++ b/__tests__/tabs.test.js
@@ -16,10 +16,7 @@ describe('browser.tabs', () => {
   test('connect', () => {
     const name = 'CONNECT_NAME';
     expect(jest.isMockFunction(chrome.tabs.connect)).toBe(true);
-    const connection = chrome.tabs.connect(
-      1,
-      { name }
-    );
+    const connection = chrome.tabs.connect(1, { name });
     expect(connection.name).toEqual(name);
     expect(jest.isMockFunction(connection.disconnect)).toBe(true);
     expect(jest.isMockFunction(connection.postMessage)).toBe(true);

--- a/__tests__/webNavigation.test.js
+++ b/__tests__/webNavigation.test.js
@@ -1,0 +1,29 @@
+describe('browser.webNavigation', () => {
+  test('onCompleted listener', () => {
+    expect(
+      jest.isMockFunction(chrome.webNavigation.onCompleted.addListener)
+    ).toBe(true);
+
+    const listener = () => {};
+    chrome.webNavigation.onCompleted.addListener(listener);
+
+    expect(chrome.webNavigation.onCompleted.addListener).toHaveBeenCalledWith(
+      listener
+    );
+  });
+
+  test('onHistoryStateUpdated listener', () => {
+    expect(
+      jest.isMockFunction(
+        chrome.webNavigation.onHistoryStateUpdated.addListener
+      )
+    ).toBe(true);
+
+    const listener = () => {};
+    chrome.webNavigation.onHistoryStateUpdated.addListener(listener);
+
+    expect(
+      chrome.webNavigation.onHistoryStateUpdated.addListener
+    ).toHaveBeenCalledWith(listener);
+  });
+});

--- a/dist/setup.js
+++ b/dist/setup.js
@@ -104,7 +104,7 @@ var onMessageListeners = [];
 var runtime = {
   connect: jest.fn(function (_ref) {
     var name = _ref.name;
-    var connection = {
+    return {
       name: name,
       postMessage: jest.fn(),
       onDisconnect: {
@@ -114,9 +114,9 @@ var runtime = {
         addListener: jest.fn(function (listener) {
           onMessageListeners.push(listener);
         })
-      }
+      },
+      disconnect: jest.fn()
     };
-    return connection;
   }),
   sendMessage: jest.fn(function (message, cb) {
     onMessageListeners.forEach(function (listener) {
@@ -154,10 +154,13 @@ var runtime = {
   },
   getURL: jest.fn(function (path) {
     return path;
-  })
+  }),
+  openOptionsPage: jest.fn()
 };
 
 function _typeof(obj) {
+  "@babel/helpers - typeof";
+
   if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
     _typeof = function (obj) {
       return typeof obj;
@@ -452,6 +455,15 @@ var i18n = {
   detectLanguage: jest.fn()
 };
 
+var webNavigation = {
+  onCompleted: {
+    addListener: jest.fn()
+  },
+  onHistoryStateUpdated: {
+    addListener: jest.fn()
+  }
+};
+
 var geckoProfiler = {
   stop: jest.fn(function () {
     return Promise.resolve();
@@ -488,7 +500,8 @@ var chrome = {
   commands: commands,
   geckoProfiler: geckoProfiler,
   notifications: notifications,
-  i18n: i18n
+  i18n: i18n,
+  webNavigation: webNavigation
 };
  // Firefox uses 'browser' but aliases it to chrome
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import { browserAction } from './browserAction';
 import { commands } from './commands';
 import { notifications } from './notifications';
 import { i18n } from './i18n';
+import { webNavigation } from './webNavigation';
 
 // Firefox specific API
 import { geckoProfiler } from './geckoProfiler';
@@ -20,6 +21,7 @@ const chrome = {
   geckoProfiler,
   notifications,
   i18n,
+  webNavigation,
 };
 
 export { chrome };

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -1,7 +1,7 @@
 let onMessageListeners = [];
 export const runtime = {
   connect: jest.fn(function({ name }) {
-    const connection = {
+    return {
       name,
       postMessage: jest.fn(),
       onDisconnect: {
@@ -12,8 +12,8 @@ export const runtime = {
           onMessageListeners.push(listener);
         }),
       },
+      disconnect: jest.fn(),
     };
-    return connection;
   }),
   sendMessage: jest.fn((message, cb) => {
     onMessageListeners.forEach(listener => listener(message));
@@ -44,4 +44,5 @@ export const runtime = {
   getURL: jest.fn(function(path) {
     return path;
   }),
+  openOptionsPage: jest.fn(),
 };

--- a/src/webNavigation.js
+++ b/src/webNavigation.js
@@ -1,0 +1,8 @@
+export const webNavigation = {
+  onCompleted: {
+    addListener: jest.fn(),
+  },
+  onHistoryStateUpdated: {
+    addListener: jest.fn(),
+  },
+};


### PR DESCRIPTION
Hi @clarkbw,

Thanks for making this library. I have found it very useful. I've managed to add a few more mocks to the `chrome.runtime` and `web.navigation` API. 

**API Reference**
* [webNavigation](https://developer.chrome.com/extensions/webNavigation)
* [openOptionPage](https://developer.chrome.com/extensions/runtime#method-openOptionsPage)
* [disconnect](https://developer.chrome.com/extensions/runtime#property-Port-disconnect)

**Changes**
* Added mocks for `onCompleted` and `onHistoryStateUpdated` webNavigation events
* Updated chrome.runtime API with `openOptionPage` and `disconnect` mocks
* Test update