### PR TITLE
feat: Add reload to tabs

### DIFF
--- a/__tests__/tabs.test.js
+++ b/__tests__/tabs.test.js
@@ -103,4 +103,13 @@ describe('browser.tabs', () => {
       expect(callback).toHaveBeenCalledTimes(0);
     });
   });
+  test('reload', (done) => {
+    const callback = jest.fn(() => done());
+    expect(jest.isMockFunction(chrome.tabs.reload)).toBe(true);
+
+    chrome.tabs.reload(1, {}, callback);
+
+    expect(chrome.tabs.reload).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -45,4 +45,5 @@ export const tabs = {
     hasListener: jest.fn(),
   },
   sendMessage: jest.fn(),
+  reload: jest.fn((tabId, reloadProperties, cb) => cb()),
 };


### PR DESCRIPTION
Hey there @jest-webextension-mock team! I was able to use your plugin over the weekend and found it very useful! While writing some tests, I came across a missing function, `reload`. 

[Here is the chrome.tabs.reload documentation](https://developer.chrome.com/extensions/tabs#method-reload).

[Here is an example of where I was using it in my repo](https://github.com/therynamo/color-links/blob/master/src/helpers/__tests__/chrome.test.ts#L51-L64).

Let me know if there is anything I should add to this pr.

Hope it is helpful! 

Thanks again for this package 👍 