### PR TITLE
tab.reload should resolve promise if no callback is provided

### DIFF
--- a/src/tabs.js
+++ b/src/tabs.js
@@ -52,5 +52,10 @@ export const tabs = {
     }
     return Promise.resolve();
   }),
-  reload: jest.fn((tabId, reloadProperties, cb) => cb()),
+  reload: jest.fn((tabId, reloadProperties, cb) => {
+    if (cb !== undefined) {
+      return cb();
+    }
+    return Promise.resolve();
+  }),
 };


### PR DESCRIPTION
I'm using `webextension-polyfill` and `await browser.tab.reload()` since it doesn't pass a callback when called this way. I've used the same pattern I see used in other parts of the codebase.