### PR TITLE
Chore/update build

### DIFF
--- a/dist/setup.js
+++ b/dist/setup.js
@@ -18,6 +18,7 @@ var omnibox = {
 };
 
 var onMessageListeners = [];
+var onMessageExternalListeners = [];
 var runtime = {
   connect: jest.fn(function (_ref) {
     var name = _ref.name;
@@ -59,6 +60,19 @@ var runtime = {
       return onMessageListeners.includes(listener);
     })
   },
+  onMessageExternal: {
+    addListener: jest.fn(function (listener) {
+      onMessageExternalListeners.push(listener);
+    }),
+    removeListener: jest.fn(function (listener) {
+      onMessageExternalListeners = onMessageExternalListeners.filter(function (lstn) {
+        return lstn !== listener;
+      });
+    }),
+    hasListener: jest.fn(function (listener) {
+      return onMessageExternalListeners.includes(listener);
+    })
+  },
   onConnect: {
     addListener: jest.fn(),
     removeListener: jest.fn(),
@@ -72,13 +86,18 @@ var runtime = {
   getURL: jest.fn(function (path) {
     return path;
   }),
-  openOptionsPage: jest.fn()
+  openOptionsPage: jest.fn(),
+  getManifest: jest.fn(function () {
+    return {
+      manifest_version: 3
+    };
+  })
 };
 
 // https://developer.chrome.com/extensions/tabs
 var tabs = {
   get: jest.fn(function () {
-    var cb = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : function () { };
+    var cb = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : function () {};
     return cb({});
   }),
   getCurrent: jest.fn(function (cb) {
@@ -119,23 +138,23 @@ var tabs = {
   }),
   duplicate: jest.fn(function () {
     var id = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
-    var cb = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : function () { };
+    var cb = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : function () {};
     return cb(Object.assign({}, {
       id: id
     }));
   }),
   query: jest.fn(function () {
-    var cb = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : function () { };
+    var cb = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : function () {};
     return cb([{}]);
   }),
   highlight: jest.fn(function () {
-    var cb = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : function () { };
+    var cb = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : function () {};
     return cb();
   }),
   update: jest.fn(function () {
     var id = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
     var props = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    var cb = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : function () { };
+    var cb = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : function () {};
     return cb(Object.assign({}, props, {
       id: id
     }));
@@ -143,7 +162,7 @@ var tabs = {
   move: jest.fn(function () {
     var ids = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : [];
     var props = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
-    var cb = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : function () { };
+    var cb = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : function () {};
     return cb(ids.map(function (id) {
       return Object.assign({}, props, {
         id: id
@@ -481,20 +500,46 @@ var extension = {
   getURL: jest.fn()
 };
 
+var cbOrPromise$1 = function cbOrPromise(cb, value) {
+  if (cb !== undefined) {
+    return cb(value);
+  }
+
+  return Promise.resolve(value);
+};
+
 var downloads = {
-  acceptDanger: jest.fn((downloadId, cb) => cbOrPromise(cb)),
-  cancel: jest.fn((downloadId, cb) => cbOrPromise(cb)),
-  download: jest.fn((options, cb) => cbOrPromise(cb)),
-  erase: jest.fn((query, cb) => cbOrPromise(cb)),
-  getFileIcon: jest.fn((downloadId, cb) => cbOrPromise(cb)),
+  acceptDanger: jest.fn(function (downloadId, cb) {
+    return cbOrPromise$1(cb);
+  }),
+  cancel: jest.fn(function (downloadId, cb) {
+    return cbOrPromise$1(cb);
+  }),
+  download: jest.fn(function (options, cb) {
+    return cbOrPromise$1(cb);
+  }),
+  erase: jest.fn(function (query, cb) {
+    return cbOrPromise$1(cb);
+  }),
+  getFileIcon: jest.fn(function (downloadId, cb) {
+    return cbOrPromise$1(cb);
+  }),
   open: jest.fn(),
-  pause: jest.fn((downloadId, cb) => cbOrPromise(cb)),
-  removeFile: jest.fn((downloadId, cb) => cbOrPromise(cb)),
-  resume: jest.fn((downloadId, cb) => cbOrPromise(cb)),
-  search: jest.fn((query, cb) => cbOrPromise(cb)),
+  pause: jest.fn(function (downloadId, cb) {
+    return cbOrPromise$1(cb);
+  }),
+  removeFile: jest.fn(function (downloadId, cb) {
+    return cbOrPromise$1(cb);
+  }),
+  resume: jest.fn(function (downloadId, cb) {
+    return cbOrPromise$1(cb);
+  }),
+  search: jest.fn(function (query, cb) {
+    return cbOrPromise$1(cb);
+  }),
   setShelfEnabled: jest.fn(),
   show: jest.fn(),
-  showDefaultFolder: jest.fn(),
+  showDefaultFolder: jest.fn()
 };
 
 var geckoProfiler = {
@@ -536,9 +581,9 @@ var chrome = {
   i18n: i18n,
   webNavigation: webNavigation,
   extension: extension,
-  downloads: downloads,
+  downloads: downloads
 };
-// Firefox uses 'browser' but aliases it to chrome
+ // Firefox uses 'browser' but aliases it to chrome
 
 /**
  * This is a setup file we specify as our 'main' entry point

--- a/package.json
+++ b/package.json
@@ -44,5 +44,6 @@
         "setupFiles": [
             "./__setups__/chrome.js"
         ]
-    }
+    },
+    "dependencies": {}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1886,9 +1886,9 @@ camelcase@^6.0.0:
   integrity sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ==
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001228"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz#bfdc5942cd3326fa51ee0b42fbef4da9d492a7fa"
-  integrity sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==
+  version "1.0.30001434"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz"
+  integrity sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Noticed that even after updating to [v3.8.0](https://www.npmjs.com/package/jest-webextension-mock/v/3.8.0) jest still failed. I guess because it's using the build which makes sense.  
Noticed that the build hasn't been updated for a longer time.  
This should fix it 🤞  
Would need another release I guess.

You want to add 3.8.0 to [the releases](https://github.com/clarkbw/jest-webextension-mock/releases) as well?