### PR TITLE
chore: fail when setup hasn't been built and committed

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,7 +29,7 @@ jobs:
       - name: check dist build
         run: |
           if ! git diff --quiet --exit-code dist/setup.js; then
-            echo "::error run `npm run build` and commit the dist/setup.js file"
+            echo "::error run 'npm run build' and commit the dist/setup.js file"
             exit 1
           fi
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,8 +27,9 @@ jobs:
       - run: npm run build --if-present
       - run: git status --porcelain dist/setup.js
       - name: check dist build
-        if: ${{ "$(git status --porcelain dist/setup.js)" }}
         run: |
-          echo "::error run `npm run build` and commit the dist/setup.js file"
-          exit 1
+          if git diff --exit-code dist/setup.js; then
+            echo "::error run `npm run build` and commit the dist/setup.js file"
+            exit 1
+          fi
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,7 +28,7 @@ jobs:
       - run: git status --porcelain dist/setup.js
       - name: check dist build
         run: |
-          if git diff --exit-code dist/setup.js; then
+          if ! git diff --quiet --exit-code dist/setup.js; then
             echo "::error run `npm run build` and commit the dist/setup.js file"
             exit 1
           fi

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,4 +26,9 @@ jobs:
       - run: npm test
       - run: npm run build --if-present
       - run: git status --porcelain dist/setup.js
+      - name: check dist build
+        if: ${{ "$(git status --porcelain dist/setup.js)" }}
+        run: |
+          echo "::error run `npm run build` and commit the dist/setup.js file"
+          exit 1
       - uses: codecov/codecov-action@v3

--- a/dist/setup.js
+++ b/dist/setup.js
@@ -193,17 +193,11 @@ var tabs = {
 function _typeof(obj) {
   "@babel/helpers - typeof";
 
-  if (typeof Symbol === "function" && typeof Symbol.iterator === "symbol") {
-    _typeof = function (obj) {
-      return typeof obj;
-    };
-  } else {
-    _typeof = function (obj) {
-      return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
-    };
-  }
-
-  return _typeof(obj);
+  return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) {
+    return typeof obj;
+  } : function (obj) {
+    return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
+  }, _typeof(obj);
 }
 
 var store = {};
@@ -425,7 +419,7 @@ var commands = {
   }
 };
 
-var cbOrPromise = function cbOrPromise(cb, value) {
+var cbOrPromise$1 = function cbOrPromise(cb, value) {
   if (cb !== undefined) {
     return cb(value);
   }
@@ -442,22 +436,22 @@ var create = function create(notificationId, options, cb) {
     cb = options;
   }
 
-  return cbOrPromise(cb, notificationId);
+  return cbOrPromise$1(cb, notificationId);
 };
 
 var notifications = {
   create: jest.fn(create),
   update: jest.fn(function (notificationId, options, cb) {
-    return cbOrPromise(cb, true);
+    return cbOrPromise$1(cb, true);
   }),
   clear: jest.fn(function (notificationId, cb) {
-    return cbOrPromise(cb, true);
+    return cbOrPromise$1(cb, true);
   }),
   getAll: jest.fn(function (cb) {
-    return cbOrPromise(cb, []);
+    return cbOrPromise$1(cb, []);
   }),
   getPermissionLevel: jest.fn(function (cb) {
-    return cbOrPromise(cb, 'granted');
+    return cbOrPromise$1(cb, 'granted');
   }),
   onClosed: {
     addListener: jest.fn()
@@ -500,7 +494,7 @@ var extension = {
   getURL: jest.fn()
 };
 
-var cbOrPromise$1 = function cbOrPromise(cb, value) {
+var cbOrPromise = function cbOrPromise(cb, value) {
   if (cb !== undefined) {
     return cb(value);
   }
@@ -510,32 +504,32 @@ var cbOrPromise$1 = function cbOrPromise(cb, value) {
 
 var downloads = {
   acceptDanger: jest.fn(function (downloadId, cb) {
-    return cbOrPromise$1(cb);
+    return cbOrPromise(cb);
   }),
   cancel: jest.fn(function (downloadId, cb) {
-    return cbOrPromise$1(cb);
+    return cbOrPromise(cb);
   }),
   download: jest.fn(function (options, cb) {
-    return cbOrPromise$1(cb);
+    return cbOrPromise(cb);
   }),
   erase: jest.fn(function (query, cb) {
-    return cbOrPromise$1(cb);
+    return cbOrPromise(cb);
   }),
   getFileIcon: jest.fn(function (downloadId, cb) {
-    return cbOrPromise$1(cb);
+    return cbOrPromise(cb);
   }),
   open: jest.fn(),
   pause: jest.fn(function (downloadId, cb) {
-    return cbOrPromise$1(cb);
+    return cbOrPromise(cb);
   }),
   removeFile: jest.fn(function (downloadId, cb) {
-    return cbOrPromise$1(cb);
+    return cbOrPromise(cb);
   }),
   resume: jest.fn(function (downloadId, cb) {
-    return cbOrPromise$1(cb);
+    return cbOrPromise(cb);
   }),
   search: jest.fn(function (query, cb) {
-    return cbOrPromise$1(cb);
+    return cbOrPromise(cb);
   }),
   setShelfEnabled: jest.fn(),
   show: jest.fn(),


### PR DESCRIPTION
Now to prevent these shenanigans we'll fail the build / test workflow when the `dist/setup.js` file hasn't been properly built and committed as part of the PR.

(should fail for the first run here)