### PR TITLE
Fix incorrect behavior of `runtime.getURL`

### DIFF
--- a/__tests__/runtime.test.js
+++ b/__tests__/runtime.test.js
@@ -29,9 +29,10 @@ describe('browser.runtime', () => {
   });
   test('getURL', () => {
     const path = 'TEST_PATH';
+    const extensionOriginURL = globalThis[Symbol.for('jest-webextension-mock')].extensionPath;
     expect(jest.isMockFunction(browser.runtime.getURL)).toBe(true);
     const respPath = browser.runtime.getURL(path);
-    expect(respPath).toEqual(path);
+    expect(respPath).toEqual(extensionOriginURL + path);
     expect(browser.runtime.getURL).toHaveBeenCalledTimes(1);
   });
   test('sendMessage', (done) => {

--- a/dist/setup.js
+++ b/dist/setup.js
@@ -1,5 +1,56 @@
 'use strict';
 
+function ownKeys(object, enumerableOnly) {
+  var keys = Object.keys(object);
+
+  if (Object.getOwnPropertySymbols) {
+    var symbols = Object.getOwnPropertySymbols(object);
+    enumerableOnly && (symbols = symbols.filter(function (sym) {
+      return Object.getOwnPropertyDescriptor(object, sym).enumerable;
+    })), keys.push.apply(keys, symbols);
+  }
+
+  return keys;
+}
+
+function _objectSpread2(target) {
+  for (var i = 1; i < arguments.length; i++) {
+    var source = null != arguments[i] ? arguments[i] : {};
+    i % 2 ? ownKeys(Object(source), !0).forEach(function (key) {
+      _defineProperty(target, key, source[key]);
+    }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) {
+      Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
+    });
+  }
+
+  return target;
+}
+
+function _typeof(obj) {
+  "@babel/helpers - typeof";
+
+  return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) {
+    return typeof obj;
+  } : function (obj) {
+    return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
+  }, _typeof(obj);
+}
+
+function _defineProperty(obj, key, value) {
+  if (key in obj) {
+    Object.defineProperty(obj, key, {
+      value: value,
+      enumerable: true,
+      configurable: true,
+      writable: true
+    });
+  } else {
+    obj[key] = value;
+  }
+
+  return obj;
+}
+
 // https://developer.chrome.com/extensions/omnibox
 var omnibox = {
   setDefaultSuggestion: jest.fn(),
@@ -84,7 +135,8 @@ var runtime = {
     hasListener: jest.fn()
   },
   getURL: jest.fn(function (path) {
-    return path;
+    var origin = globalThis[Symbol["for"]('jest-webextension-mock')].extensionPath;
+    return String(new URL(path, origin));
   }),
   openOptionsPage: jest.fn(),
   getManifest: jest.fn(function () {
@@ -189,16 +241,6 @@ var tabs = {
     return cb();
   })
 };
-
-function _typeof(obj) {
-  "@babel/helpers - typeof";
-
-  return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) {
-    return typeof obj;
-  } : function (obj) {
-    return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
-  }, _typeof(obj);
-}
 
 var store = {};
 
@@ -563,6 +605,9 @@ var geckoProfiler = {
   }
 };
 
+globalThis[Symbol["for"]('jest-webextension-mock')] = _objectSpread2({
+  extensionPath: 'moz-extension://8b413e68-1e0d-4cad-b98e-1eb000799783/'
+}, globalThis[Symbol["for"]('jest-webextension-mock')]);
 var chrome = {
   omnibox: omnibox,
   tabs: tabs,

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,11 @@ import { downloads } from './downloads';
 // Firefox specific API
 import { geckoProfiler } from './geckoProfiler';
 
+globalThis[Symbol.for('jest-webextension-mock')] = {
+	extensionPath: 'moz-extension://8b413e68-1e0d-4cad-b98e-1eb000799783/',
+  ...globalThis[Symbol.for('jest-webextension-mock')]
+};
+
 const chrome = {
   omnibox,
   tabs,

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -56,7 +56,8 @@ export const runtime = {
     hasListener: jest.fn(),
   },
   getURL: jest.fn(function (path) {
-    return path;
+    const origin = globalThis[Symbol.for('jest-webextension-mock')].extensionPath;
+    return new URL(path, origin);
   }),
   openOptionsPage: jest.fn(),
   getManifest: jest.fn(() => ({ manifest_version: 3 })),

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -57,7 +57,7 @@ export const runtime = {
   },
   getURL: jest.fn(function (path) {
     const origin = globalThis[Symbol.for('jest-webextension-mock')].extensionPath;
-    return new URL(path, origin);
+    return String(new URL(path, origin));
   }),
   openOptionsPage: jest.fn(),
   getManifest: jest.fn(() => ({ manifest_version: 3 })),


### PR DESCRIPTION
Now `browser.runtime.getURL` returns path from first argument instead of path + extension URL prefix.

I suggest changes to fix this behavior.
Here we use a global object to configure extension URL