### PR TITLE
feat: add tabs.onRemoved and tabs.onCreated mocks

### DIFF
--- a/__tests__/tabs.test.js
+++ b/__tests__/tabs.test.js
@@ -102,6 +102,22 @@ describe('browser.tabs', () => {
       expect(browser.tabs.onUpdated[method]).toHaveBeenCalledTimes(1);
       expect(callback).toHaveBeenCalledTimes(0);
     });
+
+    test(`onRemoved.${method}`, () => {
+      const callback = jest.fn();
+      expect(jest.isMockFunction(browser.tabs.onRemoved[method])).toBe(true);
+      browser.tabs.onRemoved[method](callback);
+      expect(browser.tabs.onRemoved[method]).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledTimes(0);
+    });
+
+    test(`onCreated.${method}`, () => {
+      const callback = jest.fn();
+      expect(jest.isMockFunction(browser.tabs.onCreated[method])).toBe(true);
+      browser.tabs.onCreated[method](callback);
+      expect(browser.tabs.onCreated[method]).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledTimes(0);
+    });
   });
   test('reload', (done) => {
     const callback = jest.fn(() => done());

--- a/dist/setup.js
+++ b/dist/setup.js
@@ -226,6 +226,16 @@ var tabs = {
     removeListener: jest.fn(),
     hasListener: jest.fn()
   },
+  onRemoved: {
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    hasListener: jest.fn()
+  },
+  onCreated: {
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    hasListener: jest.fn()
+  },
   sendMessage: jest.fn(function (tabId, message, cb) {
     onMessageListeners.forEach(function (listener) {
       return listener(tabId, message);

--- a/src/tabs.js
+++ b/src/tabs.js
@@ -45,6 +45,16 @@ export const tabs = {
     removeListener: jest.fn(),
     hasListener: jest.fn(),
   },
+  onRemoved: {
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    hasListener: jest.fn(),
+  },
+  onCreated: {
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    hasListener: jest.fn(),
+  },
   sendMessage: jest.fn((tabId, message, cb) => {
     onMessageListeners.forEach((listener) => listener(tabId, message));
     if (cb !== undefined) {


### PR DESCRIPTION
Hello 👋 

I'm a core contributor to Adblock plus and i'm experimenting with using this library to help us write more unit tests.
I noticed that it misses a few methods on the tabs API that we would need to make use of, also noticed the issue #107 where somebody else encountered a similar problem.

I took a (very) quick stab at adding those missing methods:
- [`tabs.onCreated`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onCreated)
- [`tabs.onRemoved`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onRemoved)

I followed the existing pattern that exists with `onUpdated`, i.e. I did not implement mock functionalities to make the `addListener`, `removeListener` and `hasListener` work (we could for an example keep track of the functions added as listeners and return correct values in `hasListener`), but simply mocked them with `jest.fn()`.

Looking forward to feedback to on this 🤞 